### PR TITLE
Update View.removed.kt

### DIFF
--- a/android-bindings/src/main/java/com/lightningkite/rx/android/View.removed.kt
+++ b/android-bindings/src/main/java/com/lightningkite/rx/android/View.removed.kt
@@ -16,7 +16,7 @@ val View.removed: CompositeDisposable
             val composite = CompositeDisposable()
             this.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
                 override fun onViewDetachedFromWindow(v: View) {
-                    composite.dispose()
+                    composite.clear()
                     v.removeOnAttachStateChangeListener(this)
                 }
 


### PR DESCRIPTION
changed View.removed to call clear() on the disposable, calling dispose() renders the Composite Disposable unusable, which in some cases, like RecyclerView adapters is not the desired behavior.